### PR TITLE
Add button to Deploy to Heroku 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,33 +8,39 @@ Notification determined from Harvest API V2.
 
 ## Quick Start
 
+1. Сlone repo
+
 ```bash
-# Сlone repo
 git clone git@github.com:fs/harvest-notifier.git
 cd harvest-notifier
-
-# Setup project
+```
+2. Setup project
+```bash
 bin/setup
+```
 
-# Prepare access tokens
+3. Prepare access tokens
 
-# Create Personal Access Tokens on Harvest
-[![Harvest](https://www.getharvest.com/assets/press/harvest-logo-capsule-9b74927af1c93319c7d6c47ee89d4c2d442f569492c82899b203dd3bdeaa81a4.png)](https://id.getharvest.com/developers)
+  3.1 Create Personal Access Tokens on Harvest
+  [![Harvest](https://www.getharvest.com/assets/press/harvest-logo-capsule-9b74927af1c93319c7d6c47ee89d4c2d442f569492c82899b203dd3bdeaa81a4.png)](https://id.getharvest.com/developers)
 
-# Create Slack app
-[![Slack](https://cdn.brandfolder.io/5H442O3W/at/pl546j-7le8zk-6gwiyo/Slack_Mark.svg)](https://api.slack.com/apps)
+  3.2 Create Slack app
+  [![Slack](https://cdn.brandfolder.io/5H442O3W/at/pl546j-7le8zk-6gwiyo/Slack_Mark.svg)](https://api.slack.com/apps)
 
-Create Bot User OAuth Access Token
-Add following scopes:
-chat:write
-incoming-webhook
-users:read
-users:read.email
+  3.3 Create Bot User OAuth Access Token
+  3.4 Add following scopes:
+  ```bash
+  chat:write
+  incoming-webhook
+  users:read
+  users:read.email
+  ```
 
-# Create Heroku app
+4. Create Heroku app
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/fs/harvest-notifier)
 
-# Configure following ENV variables
+5. Configure following ENV variables
+```bash
 heroku config:set ROLLBAR_ACCESS_TOKEN=
 heroku config:set SNITCH_DAILY=
 heroku config:set HARVEST_TOKEN=

--- a/README.md
+++ b/README.md
@@ -6,30 +6,36 @@ This is a ruby library to install on Daily Heroku Scheduler.
 It will notification in Slack about users who forgot to mark their working hours in Harvest.
 Notification determined from Harvest API V2.
 
-## Install
+## Quick Start
 
-```
-#Setup
+```bash
+# Сlone repo
+git clone git@github.com:fs/harvest-notifier.git
+cd harvest-notifier
+
+# Setup project
 bin/setup
 
+# Prepare access tokens
+
+# Create Personal Access Tokens on Harvest
+[![Harvest](https://www.getharvest.com/assets/press/harvest-logo-capsule-9b74927af1c93319c7d6c47ee89d4c2d442f569492c82899b203dd3bdeaa81a4.png)](https://id.getharvest.com/developers)
+
+# Create Slack app
+[![Slack](https://cdn.brandfolder.io/5H442O3W/at/pl546j-7le8zk-6gwiyo/Slack_Mark.svg)](https://api.slack.com/apps)
+
+Create Bot User OAuth Access Token
+Add following scopes:
+chat:write
+incoming-webhook
+users:read
+users:read.email
+
 # Create Heroku app
-heroku create harvest-notifier
-
-# Create Heroku Scheduler
-heroku addons:create scheduler:standard
-
-# Open Heroku Scheduler and create daily job with `bin/rake reports:daily or reports:weekly`
-heroku addons:open scheduler
-
-# Create Rollbar addon to track exceptions
-heroku addons:create rollbar:free
-
-# Create Little Snitch to track daily execution
-# And configure it to define `SNITCH_DAILY`
-heroku addons:create deadmanssnitch
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/fs/harvest-notifier)
 
 # Configure following ENV variables
-heroku config:set ROLLBAR_ENV=production
+heroku config:set ROLLBAR_ACCESS_TOKEN=
 heroku config:set SNITCH_DAILY=
 heroku config:set HARVEST_TOKEN=
 heroku config:set HARVEST_ACCOUNT_ID=

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Harvest Notifier Script
 
 [![Build Status](https://flatstack.semaphoreci.com/badges/harvest-notifier.svg)](https://flatstack.semaphoreci.com/projects/harvest-notifier)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/fs/harvest-notifier)
 
 This is a ruby library to install on Daily Heroku Scheduler.
 It will notification in Slack about users who forgot to mark their working hours in Harvest.

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Notification determined from Harvest API V2.
 ## Quick Start
 
 1. Сlone repo
-
 ```bash
 git clone git@github.com:fs/harvest-notifier.git
 cd harvest-notifier
 ```
+
 2. Setup project
 ```bash
 bin/setup
@@ -31,7 +31,7 @@ bin/setup
   users:read.email
   ```
 
-4. [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/fs/harvest-notifier)
+4. [Deploy to Heroku](https://heroku.com/deploy?template=https://github.com/fs/harvest-notifier)
 
 5. Configure following ENV variables
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,15 +20,10 @@ bin/setup
 ```
 
 3. Prepare access tokens
-
-  3.1 Create Personal Access Tokens on Harvest
-  [![Harvest](https://www.getharvest.com/assets/press/harvest-logo-capsule-9b74927af1c93319c7d6c47ee89d4c2d442f569492c82899b203dd3bdeaa81a4.png){:height="250px" width="250px"}](https://id.getharvest.com/developers)
-
-  3.2 Create Slack app
-  [![Slack](https://cdn.brandfolder.io/5H442O3W/at/pl546j-7le8zk-6gwiyo/Slack_Mark.svg){:height="250px" width="250px"}](https://api.slack.com/apps)
-
-  3.3 Create Bot User OAuth Access Token
-  3.4 Add following scopes:
+  * Create Personal Access Tokens on Harvest: https://id.getharvest.com/developers
+  * Create Slack app: https://api.slack.com/apps
+  * Create Bot User OAuth Access Token
+  * Add following scopes:
   ```bash
   chat:write
   incoming-webhook

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ bin/setup
 3. Prepare access tokens
 
   3.1 Create Personal Access Tokens on Harvest
-  [![Harvest](https://www.getharvest.com/assets/press/harvest-logo-capsule-9b74927af1c93319c7d6c47ee89d4c2d442f569492c82899b203dd3bdeaa81a4.png =250x250)](https://id.getharvest.com/developers)
+  [![Harvest](https://www.getharvest.com/assets/press/harvest-logo-capsule-9b74927af1c93319c7d6c47ee89d4c2d442f569492c82899b203dd3bdeaa81a4.png){:height="250px" width="250px"}](https://id.getharvest.com/developers)
 
   3.2 Create Slack app
-  [![Slack](https://cdn.brandfolder.io/5H442O3W/at/pl546j-7le8zk-6gwiyo/Slack_Mark.svg =250x250)](https://api.slack.com/apps)
+  [![Slack](https://cdn.brandfolder.io/5H442O3W/at/pl546j-7le8zk-6gwiyo/Slack_Mark.svg){:height="250px" width="250px"}](https://api.slack.com/apps)
 
   3.3 Create Bot User OAuth Access Token
   3.4 Add following scopes:

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ bin/setup
 3. Prepare access tokens
 
   3.1 Create Personal Access Tokens on Harvest
-  [![Harvest](https://www.getharvest.com/assets/press/harvest-logo-capsule-9b74927af1c93319c7d6c47ee89d4c2d442f569492c82899b203dd3bdeaa81a4.png)](https://id.getharvest.com/developers)
+  [![Harvest](https://www.getharvest.com/assets/press/harvest-logo-capsule-9b74927af1c93319c7d6c47ee89d4c2d442f569492c82899b203dd3bdeaa81a4.png =250x250)](https://id.getharvest.com/developers)
 
   3.2 Create Slack app
-  [![Slack](https://cdn.brandfolder.io/5H442O3W/at/pl546j-7le8zk-6gwiyo/Slack_Mark.svg)](https://api.slack.com/apps)
+  [![Slack](https://cdn.brandfolder.io/5H442O3W/at/pl546j-7le8zk-6gwiyo/Slack_Mark.svg =250x250)](https://api.slack.com/apps)
 
   3.3 Create Bot User OAuth Access Token
   3.4 Add following scopes:
@@ -36,8 +36,7 @@ bin/setup
   users:read.email
   ```
 
-4. Create Heroku app
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/fs/harvest-notifier)
+4. [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/fs/harvest-notifier)
 
 5. Configure following ENV variables
 ```bash

--- a/app.json
+++ b/app.json
@@ -1,0 +1,47 @@
+{
+  "name": "Harvest Notifier",
+  "description": "Automatic notification script for Slack based on Harvest data",
+  "repository": "https://github.com/fs/harvest-notifier/",
+  "keywords": [
+    "harvest",
+    "notification",
+    "slack"
+  ],
+  "env": {
+    "ROLLBAR_ACCESS_TOKEN": {
+      "required": true
+    },
+    "SNITCH_DAILY": {
+      "required": true
+    },
+    "SECRET_KEY_BASE": {
+      "generator": "secret"
+    },
+    "HARVEST_TOKEN": {
+      "required": true
+    },
+    "HARVEST_ACCOUNT_ID": {
+      "required": true
+    },
+    "SLACK_TOKEN": {
+      "required": true
+    },
+    "EMAILS_WHITELIST": {
+      "required": false
+    },
+    "HARVEST_URL": {
+      "required": false
+    },
+    "MISSING_HOURS_THRESHOLD": {
+      "required": false
+    },
+    "SLACK_CHANNEL": {
+      "required": false
+    }
+  },
+  "addons": [
+    "deadmanssnitch:the-lone-snitch",
+    "scheduler:standard",
+    "rollbar:free"
+  ]
+}

--- a/app.json
+++ b/app.json
@@ -43,5 +43,10 @@
     "deadmanssnitch:the-lone-snitch",
     "scheduler:standard",
     "rollbar:free"
+  ],
+  "buildpacks": [
+    {
+      "url": "heroku/ruby"
+    }
   ]
 }


### PR DESCRIPTION
Add button tp Deploy to Heroku.
Test: https://heroku.com/deploy?template=https://github.com/fs/harvest-notifier/tree/add-heroku-deploy
![Снимок экрана от 2020-05-11 12-29-47](https://user-images.githubusercontent.com/49876756/81546490-217c1400-9383-11ea-8066-61236afcb59a.png)

