### PR TITLE
Add skip reports from unactive users

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,7 +37,7 @@ GEM
     parser (2.7.1.1)
       ast (~> 2.4.0)
     public_suffix (4.0.4)
-    rack (2.2.2)
+    rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (3.0.0)

--- a/lib/harvest_notifier/report.rb
+++ b/lib/harvest_notifier/report.rb
@@ -65,6 +65,9 @@ module HarvestNotifier
     def with_reports(reports)
       reports["results"].each.with_object(harvest_users) do |report, result|
         id = report["user_id"]
+
+        next unless result[id]
+
         reported_hours = report["total_hours"].to_f
 
         result[id]["missing_hours"] -= reported_hours

--- a/lib/harvest_notifier/report.rb
+++ b/lib/harvest_notifier/report.rb
@@ -63,15 +63,15 @@ module HarvestNotifier
     end
 
     def with_reports(reports)
-      reports["results"].each.with_object(harvest_users) do |report, result|
+      reports["results"].each.with_object(harvest_users) do |report, users|
         id = report["user_id"]
 
-        next unless result[id]
+        next unless users.include?(id)
 
         reported_hours = report["total_hours"].to_f
 
-        result[id]["missing_hours"] -= reported_hours
-        result[id]["total_hours"] += reported_hours
+        users[id]["missing_hours"] -= reported_hours
+        users[id]["total_hours"] += reported_hours
       end
     end
 

--- a/spec/harvest_notifier/report_spec.rb
+++ b/spec/harvest_notifier/report_spec.rb
@@ -38,7 +38,8 @@ describe HarvestNotifier::Report do
       "harvest_id" => 567,
       "email" => "alex.gordon@example.com",
       "weekly_capacity" => 144_000,
-      "slack_id" => "U04TEST"
+      "slack_id" => "U04TEST",
+      "is_active" => false
     }
   end
 

--- a/spec/harvest_notifier/report_spec.rb
+++ b/spec/harvest_notifier/report_spec.rb
@@ -115,7 +115,7 @@ describe HarvestNotifier::Report do
       expect(report.daily(date)).not_to include(include(email: john_doe["email"]))
     end
 
-    it "does not return unactive user Alex Gordon" do
+    it "does not return inactive user Alex Gordon" do
       expect(report.daily(date)).not_to include(include(email: alex_gordon["email"]))
     end
   end

--- a/spec/harvest_notifier/report_spec.rb
+++ b/spec/harvest_notifier/report_spec.rb
@@ -33,6 +33,15 @@ describe HarvestNotifier::Report do
     }
   end
 
+  let(:alex_gordon) do
+    {
+      "harvest_id" => 567,
+      "email" => "alex.gordon@example.com",
+      "weekly_capacity" => 144_000,
+      "slack_id" => "U04TEST"
+    }
+  end
+
   let(:harvest_users) do
     {
       "users" => [
@@ -83,6 +92,10 @@ describe HarvestNotifier::Report do
           {
             "user_id" => john_smith["harvest_id"],
             "total_hours" => 6.0
+          },
+          {
+            "user_id" => alex_gordon["harvest_id"],
+            "total_hours" => 5.0
           }
         ]
       }
@@ -100,6 +113,10 @@ describe HarvestNotifier::Report do
     it "does not return John Doe contractor" do
       expect(report.daily(date)).not_to include(include(email: john_doe["email"]))
     end
+
+    it "does not return unactive user Alex Gordon" do
+      expect(report.daily(date)).not_to include(include(email: alex_gordon["email"]))
+    end
   end
 
   describe "#weekly" do
@@ -115,6 +132,10 @@ describe HarvestNotifier::Report do
           {
             "user_id" => bill_doe["harvest_id"],
             "total_hours" => 39.00
+          },
+          {
+            "user_id" => alex_gordon["harvest_id"],
+            "total_hours" => 5.0
           }
         ]
       }
@@ -135,6 +156,10 @@ describe HarvestNotifier::Report do
 
     it "does not return Bill Doe with missing 1 hour b/c of threshold default 1.0 hour" do
       expect(report.weekly).not_to include(include(email: bill_doe["email"]))
+    end
+
+    it "does not return unactive user Alex Gordon" do
+      expect(report.weekly).not_to include(include(email: alex_gordon["email"]))
     end
   end
 end

--- a/spec/harvest_notifier/report_spec.rb
+++ b/spec/harvest_notifier/report_spec.rb
@@ -159,7 +159,7 @@ describe HarvestNotifier::Report do
       expect(report.weekly).not_to include(include(email: bill_doe["email"]))
     end
 
-    it "does not return unactive user Alex Gordon" do
+    it "does not return inactive user Alex Gordon" do
       expect(report.weekly).not_to include(include(email: alex_gordon["email"]))
     end
   end


### PR DESCRIPTION
Skipping a report from an inactive user.
Update rack from 2.2.2 to 2.2.3 due to vulnerability.