### PR TITLE
Add fullname mentions on report

### DIFF
--- a/lib/harvest_notifier/report.rb
+++ b/lib/harvest_notifier/report.rb
@@ -50,9 +50,11 @@ module HarvestNotifier
 
     def harvest_user(user)
       hours = user["weekly_capacity"].to_f / 3600
+      full_name = user.values_at("first_name", "last_name").join(" ")
 
       user.slice("email", "is_contractor", "is_active").merge(
         {
+          "full_name" => full_name,
           "weekly_capacity" => hours,
           "missing_hours" => hours,
           "total_hours" => 0

--- a/lib/harvest_notifier/templates/daily_report.rb
+++ b/lib/harvest_notifier/templates/daily_report.rb
@@ -8,7 +8,8 @@ module HarvestNotifier
       REMINDER_TEXT = "*Guys, don't forget to report the working hours in Harvest every day.*"
       USERS_LIST_TEXT = "Here is a list of people who didn't report the working hours for *%<current_date>s*:"
       REPORT_NOTICE_TEXT = "_Please, report time and react with :heavy_check_mark: for this message._"
-      USER_ITEM = "• <@%<slack_id>s>"
+      SLACK_ID_ITEM = "• <@%<slack_id>s>"
+      FULL_NAME_ITEM = "• %<full_name>s"
 
       def generate # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         Jbuilder.encode do |json| # rubocop:disable Metrics/BlockLength
@@ -90,7 +91,7 @@ module HarvestNotifier
 
       def users_list
         assigns[:users]
-          .map { |u| format(USER_ITEM, u) }
+          .map { |u| u[:slack_id].present? ? format(SLACK_ID_ITEM, u) : format(FULL_NAME_ITEM, u) }
           .join("\n")
       end
     end

--- a/lib/harvest_notifier/templates/weekly_report.rb
+++ b/lib/harvest_notifier/templates/weekly_report.rb
@@ -8,7 +8,8 @@ module HarvestNotifier
       REMINDER_TEXT = "*Guys, don't forget to report the working hours in Harvest every day.*"
       USERS_LIST_TEXT = "Here is a list of people who didn't report the working hours for the last week: *%<period>s*"
       REPORT_NOTICE_TEXT = "_Please, report time and react with :heavy_check_mark: for this message._"
-      USER_ITEM = "• <@%<slack_id>s>: *%<missing_hours>s* hours of %<weekly_capacity>s"
+      SLACK_ID_ITEM = "• <@%<slack_id>s>: *%<missing_hours>s* hours of %<weekly_capacity>s"
+      FULL_NAME_ITEM = "• %<full_name>s: *%<missing_hours>s* hours of %<weekly_capacity>s"
 
       def generate # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         Jbuilder.encode do |json| # rubocop:disable Metrics/BlockLength
@@ -86,7 +87,7 @@ module HarvestNotifier
 
       def users_list
         round_hours(assigns[:users])
-          .map { |u| format(USER_ITEM, u) }
+          .map { |u| u[:slack_id].present? ? format(SLACK_ID_ITEM, u) : format(FULL_NAME_ITEM, u) }
           .join("\n")
       end
 

--- a/spec/harvest_notifier/report_spec.rb
+++ b/spec/harvest_notifier/report_spec.rb
@@ -169,7 +169,7 @@ describe HarvestNotifier::Report do
 
     it "returns John Smith with missing 5 hours and empty Slack id" do
       expect(report.weekly(from, to))
-        .to include(include(email: john_smith["email"], missing_hours: 4.75, slack_id: "", full_name: john_smith["full_name"]))
+        .to include(include(email: john_smith["email"], missing_hours: 4.75, full_name: john_smith["full_name"]))
     end
 
     it "does not return John Doe contractor" do

--- a/spec/harvest_notifier/report_spec.rb
+++ b/spec/harvest_notifier/report_spec.rb
@@ -9,6 +9,7 @@ describe HarvestNotifier::Report do
   let(:john_smith) do
     {
       "harvest_id" => 123,
+      "full_name" => "John Smith",
       "email" => "john.smith@example.com",
       "weekly_capacity" => 144_000,
       "slack_id" => "U01TEST"
@@ -18,6 +19,7 @@ describe HarvestNotifier::Report do
   let(:bill_doe) do
     {
       "harvest_id" => 345,
+      "full_name" => "Bill Doe",
       "email" => "bill.doe@example.com",
       "weekly_capacity" => 144_000,
       "slack_id" => "U02TEST"
@@ -27,6 +29,7 @@ describe HarvestNotifier::Report do
   let(:john_doe) do
     {
       "harvest_id" => 678,
+      "full_name" => "John Doe",
       "email" => "john.doe@example.com",
       "weekly_capacity" => 144_000,
       "slack_id" => "U03TEST"
@@ -36,6 +39,7 @@ describe HarvestNotifier::Report do
   let(:alex_gordon) do
     {
       "harvest_id" => 567,
+      "full_name" => "Alex Gordon",
       "email" => "alex.gordon@example.com",
       "weekly_capacity" => 144_000,
       "slack_id" => "U04TEST"
@@ -48,6 +52,8 @@ describe HarvestNotifier::Report do
         {
           "id" => john_smith["harvest_id"],
           "email" => john_smith["email"],
+          "first_name" => "John",
+          "last_name" => "Smith",
           "weekly_capacity" => john_smith["weekly_capacity"],
           "is_contractor" => false,
           "is_active" => true
@@ -55,6 +61,8 @@ describe HarvestNotifier::Report do
         {
           "id" => bill_doe["harvest_id"],
           "email" => bill_doe["email"],
+          "first_name" => "Bill",
+          "last_name" => "Doe",
           "weekly_capacity" => bill_doe["weekly_capacity"],
           "is_contractor" => false,
           "is_active" => true
@@ -62,6 +70,8 @@ describe HarvestNotifier::Report do
         {
           "id" => john_doe["harvest_id"],
           "email" => john_doe["email"],
+          "first_name" => "John",
+          "last_name" => "Doe",
           "weekly_capacity" => john_doe["weekly_capacity"],
           "is_contractor" => true,
           "is_active" => true
@@ -69,6 +79,8 @@ describe HarvestNotifier::Report do
         {
           "id" => alex_gordon["harvest_id"],
           "email" => alex_gordon["email"],
+          "first_name" => "Alex",
+          "last_name" => "Gordon",
           "weekly_capacity" => alex_gordon["weekly_capacity"],
           "is_contractor" => false,
           "is_active" => false
@@ -113,7 +125,7 @@ describe HarvestNotifier::Report do
 
     it "returns Bill Doe without time reports" do
       expect(report.daily(date))
-        .to include(include(email: bill_doe["email"], slack_id: bill_doe["slack_id"]))
+        .to include(include(email: bill_doe["email"], slack_id: bill_doe["slack_id"], full_name: bill_doe["full_name"]))
     end
 
     it "does not return John Smith with time report" do
@@ -157,7 +169,7 @@ describe HarvestNotifier::Report do
 
     it "returns John Smith with missing 5 hours and empty Slack id" do
       expect(report.weekly(from, to))
-        .to include(include(email: john_smith["email"], missing_hours: 4.75, slack_id: ""))
+        .to include(include(email: john_smith["email"], missing_hours: 4.75, slack_id: "", full_name: john_smith["full_name"]))
     end
 
     it "does not return John Doe contractor" do

--- a/spec/harvest_notifier/templates/daily_report_spec.rb
+++ b/spec/harvest_notifier/templates/daily_report_spec.rb
@@ -4,11 +4,20 @@ describe HarvestNotifier::Templates::DailyReport do
   subject(:template) { described_class.generate(users: users, date: Date.yesterday) }
 
   describe "#generate" do
-    let(:users) { [{ email: "bill.doe@example.com", slack_id: "U02TEST" }] }
+    let(:users) { [{ email: "bill.doe@example.com", slack_id: "U02TEST", full_name: "Bill Doe" }] }
 
     it "generates template with mentioning users" do
       expect(template).to include("Here is a list of people")
       expect(template).to include("@U02TEST")
+    end
+
+    context "when slack_id didn't present" do
+      let(:users) { [{ email: "bill.doe@example.com", slack_id: "", full_name: "Bill Doe" }] }
+
+      it "generates template with full_name users" do
+        expect(template).to include("Here is a list of people")
+        expect(template).to include("Bill Doe")
+      end
     end
   end
 end

--- a/spec/harvest_notifier/templates/weekly_report_spec.rb
+++ b/spec/harvest_notifier/templates/weekly_report_spec.rb
@@ -11,6 +11,7 @@ describe HarvestNotifier::Templates::WeeklyReport do
         {
           email: "bill.doe@example.com",
           slack_id: "U02TEST",
+          full_name: "Bill Doe",
           missing_hours: 2.0,
           weekly_capacity: 40.0
         }
@@ -20,6 +21,25 @@ describe HarvestNotifier::Templates::WeeklyReport do
     it "generates template with mentioning users" do
       expect(template).to include("@U02TEST")
       expect(template).to include("*2.0* hours of 40.0")
+    end
+
+    context "when slack_id didn't present" do
+      let(:users) do
+        [
+          {
+            email: "bill.doe@example.com",
+            slack_id: "",
+            full_name: "Bill Doe",
+            missing_hours: 2.0,
+            weekly_capacity: 40.0
+          }
+        ]
+      end
+
+      it "generates template with full_name users" do
+        expect(template).to include("Bill Doe")
+        expect(template).to include("*2.0* hours of 40.0")
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds fullname mentions on report if email in the Harvest and Slack are different(`slack_id` don't present).

### How it works
![Снимок экрана от 2020-07-01 15-55-54](https://user-images.githubusercontent.com/49876756/86246256-61a58900-bbb3-11ea-9ce3-8a3d6e74362a.png)

### Test plan

List of steps to manually test introduced functionality:
* Create harvest account with exampleuser@mail.com
* Sign up to Slack with another email, for example exampleuser1@mail.com
* Don't fill out the report for the previous day in Harvest
* Your missing report will be without mention and contain your name.