### PR TITLE
fix template app

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,6 +2,7 @@
   "name": "Harvest Notifier",
   "description": "Automatic notification script for Slack based on Harvest data",
   "repository": "https://github.com/fs/harvest-notifier/",
+  "stack": "heroku-18",
   "keywords": [
     "harvest",
     "notification",
@@ -45,7 +46,7 @@
   "addons": [
     "deadmanssnitch:the-lone-snitch",
     "scheduler:standard",
-    "rollbar:free"
+    "rollbar:trial-5k"
   ],
   "buildpacks": [
     {


### PR DESCRIPTION
Currently creating a new heroku app off the template does not work. 

Two blocking issues are raised here:
- https://github.com/fs/harvest-notifier/issues/29 I pinned the heroku stack to 18 which is the latest one supporting this version of ruby (although heroku-18 is deprecated and will be [sunset in 2023](https://help.heroku.com/X5OE6BCA/heroku-18-end-of-life-faq))
- https://github.com/fs/harvest-notifier/issues/32 Seems rollbar updated the name of this add on.

After resolving these, was able to create an app off the template (using my fork).